### PR TITLE
fix: track the correct page when going back

### DIFF
--- a/src/components/Wizard.vue
+++ b/src/components/Wizard.vue
@@ -171,12 +171,12 @@ export default {
       window.location.reload();
     },
     goBack() {
-      this.moveToStep(this.activeStep - 1);
-      this.focusContent();
       if (!this.completed) {
         // TRACK BACK
         logAction('back', this.currentChoice.question || this.currentChoice.label);
       }
+      this.moveToStep(this.activeStep - 1);
+      this.focusContent();
     },
     focusContent() {
       this.$nextTick(() => {


### PR DESCRIPTION
Track the current page in Matomo when the user clicks on the back
button, instead of the destination.